### PR TITLE
Add 'tenant' support for network resource

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -477,7 +477,12 @@ func (s *APIServer) Run(_ []string) error {
 	}
 
 	authorizationModeNames := strings.Split(s.AuthorizationMode, ",")
-	authorizer, err := apiserver.NewAuthorizerFromAuthorizationConfig(authorizationModeNames, s.AuthorizationPolicyFile, client)
+	authorizer, err := apiserver.NewAuthorizerFromAuthorizationConfig(apiserver.AuthorizerConfig{
+		AuthorizationModes:      authorizationModeNames,
+		AuthorizationPolicyFile: s.AuthorizationPolicyFile,
+		KubeClient:              client,
+		KeystonAuthURL:          s.KeystoneURL,
+	})
 	if err != nil {
 		glog.Fatalf("Invalid Authorization Config: %v", err)
 	}

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -64,7 +64,7 @@ do
 done
 
 if [ "x$GO_OUT" == "x" ]; then
-    "${KUBE_ROOT}/hack/build-go.sh" cmd/kube-proxy cmd/kube-apiserver cmd/kube-controller-manager cmd/kubelet plugin/cmd/kube-scheduler
+    "${KUBE_ROOT}/hack/build-go.sh" cmd/kube-proxy cmd/kube-apiserver cmd/kube-controller-manager cmd/kubelet cmd/kubectl plugin/cmd/kube-scheduler
 else
     echo "skipped the build."
 fi

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -144,8 +144,14 @@ type ObjectMeta struct {
 }
 
 const (
+	// TenantAdmin
+	TenantAdmin string = "admin"
 	// TenantDefault
 	TenantDefault string = "default"
+	// TenantAll is the default argument to specify on a context when you want to list or filter resources across all tenants
+	TenantAll string = ""
+	// TenantNone is the argument for a context when there is no tenant.
+	TenantNone string = ""
 	// NamespaceDefault means the object is in the default namespace which is applied when not specified by clients
 	NamespaceDefault string = "default"
 	// NamespaceAll is the default argument to specify on a context when you want to list or filter resources across all namespaces

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -162,6 +162,8 @@ const (
 	NamespaceSystem string = "kube-system"
 	// TerminationMessagePathDefault means the default path to capture the application termination message running in a container
 	TerminationMessagePathDefault string = "/dev/termination-log"
+	// NetworkNone
+	NetworkNone string = ""
 )
 
 // Volume represents a named volume in a pod that may be accessed by any containers in the pod.

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -648,6 +648,15 @@ func (n rootScopeNaming) GenerateListLink(req *restful.Request) (path, query str
 	return path, "", nil
 }
 
+// ObjectTenant returns the tenant on the object
+func (n rootScopeNaming) ObjectTenant(obj runtime.Object) (tenant string, err error) {
+	tenant, err = n.SelfLinker.Tenant(obj)
+	if err != nil {
+		return "", err
+	}
+	return tenant, nil
+}
+
 // ObjectName returns the name set on the object, or an error if the
 // name cannot be returned. Namespace is empty
 // TODO: distinguish between objects with name/namespace and without via a specific error.
@@ -723,6 +732,15 @@ func (n scopeNaming) GenerateLink(req *restful.Request, obj runtime.Object) (pat
 func (n scopeNaming) GenerateListLink(req *restful.Request) (path, query string, err error) {
 	path = req.Request.URL.Path
 	return path, "", nil
+}
+
+// ObjectTenant returns the tenant on the object
+func (n scopeNaming) ObjectTenant(obj runtime.Object) (tenant string, err error) {
+	tenant, err = n.SelfLinker.Tenant(obj)
+	if err != nil {
+		return "", err
+	}
+	return tenant, nil
 }
 
 // ObjectName returns the name and namespace set on the object, or an error if the

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -657,6 +657,11 @@ func (n rootScopeNaming) ObjectTenant(obj runtime.Object) (tenant string, err er
 	return tenant, nil
 }
 
+// SetTenant sets the tenant on the object
+func (n rootScopeNaming) SetTenant(obj runtime.Object, tenant string) error {
+	return n.SelfLinker.SetTenant(obj, tenant)
+}
+
 // ObjectName returns the name set on the object, or an error if the
 // name cannot be returned. Namespace is empty
 // TODO: distinguish between objects with name/namespace and without via a specific error.
@@ -741,6 +746,11 @@ func (n scopeNaming) ObjectTenant(obj runtime.Object) (tenant string, err error)
 		return "", err
 	}
 	return tenant, nil
+}
+
+// SetTenant sets the tenant on the object
+func (n scopeNaming) SetTenant(obj runtime.Object, tenant string) error {
+	return n.SelfLinker.SetTenant(obj, tenant)
 }
 
 // ObjectName returns the name and namespace set on the object, or an error if the

--- a/pkg/apiserver/authz.go
+++ b/pkg/apiserver/authz.go
@@ -37,8 +37,8 @@ type Attributes struct {
 // It is useful in tests and when using kubernetes in an open manner.
 type alwaysAllowAuthorizer struct{}
 
-func (alwaysAllowAuthorizer) Authorize(a authorizer.Attributes) (err error) {
-	return nil
+func (alwaysAllowAuthorizer) Authorize(a authorizer.Attributes) (tenant string, err error) {
+	return "", nil
 }
 
 func NewAlwaysAllowAuthorizer() authorizer.Authorizer {
@@ -50,8 +50,8 @@ func NewAlwaysAllowAuthorizer() authorizer.Authorizer {
 // It is useful in unit tests to force an operation to be forbidden.
 type alwaysDenyAuthorizer struct{}
 
-func (alwaysDenyAuthorizer) Authorize(a authorizer.Attributes) (err error) {
-	return errors.New("Everything is forbidden.")
+func (alwaysDenyAuthorizer) Authorize(a authorizer.Attributes) (tenant string, err error) {
+	return "", errors.New("Everything is forbidden.")
 }
 
 func NewAlwaysDenyAuthorizer() authorizer.Authorizer {

--- a/pkg/apiserver/authz.go
+++ b/pkg/apiserver/authz.go
@@ -68,19 +68,26 @@ const (
 // Keep this list in sync with constant list above.
 var AuthorizationModeChoices = []string{ModeAlwaysAllow, ModeAlwaysDeny, ModeABAC, ModeKeystone}
 
+type AuthorizerConfig struct {
+	AuthorizationModes      []string
+	AuthorizationPolicyFile string
+	KubeClient              client.Interface
+	KeystonAuthURL          string
+}
+
 // NewAuthorizerFromAuthorizationConfig returns the right sort of union of multiple authorizer.Authorizer objects
 // based on the authorizationMode or an error.  authorizationMode should be a comma separated values
 // of AuthorizationModeChoices.
-func NewAuthorizerFromAuthorizationConfig(authorizationModes []string, authorizationPolicyFile string, kubeClient client.Interface) (authorizer.Authorizer, error) {
+func NewAuthorizerFromAuthorizationConfig(authzConfig AuthorizerConfig) (authorizer.Authorizer, error) {
 
-	if len(authorizationModes) == 0 {
+	if len(authzConfig.AuthorizationModes) == 0 {
 		return nil, errors.New("Atleast one authorization mode should be passed")
 	}
 
 	var authorizers []authorizer.Authorizer
 	authorizerMap := make(map[string]bool)
 
-	for _, authorizationMode := range authorizationModes {
+	for _, authorizationMode := range authzConfig.AuthorizationModes {
 		if authorizerMap[authorizationMode] {
 			return nil, fmt.Errorf("Authorization mode %s specified more than once", authorizationMode)
 		}
@@ -91,16 +98,19 @@ func NewAuthorizerFromAuthorizationConfig(authorizationModes []string, authoriza
 		case ModeAlwaysDeny:
 			authorizers = append(authorizers, NewAlwaysDenyAuthorizer())
 		case ModeABAC:
-			if authorizationPolicyFile == "" {
+			if authzConfig.AuthorizationPolicyFile == "" {
 				return nil, errors.New("ABAC's authorization policy file not passed")
 			}
-			abacAuthorizer, err := abac.NewFromFile(authorizationPolicyFile)
+			abacAuthorizer, err := abac.NewFromFile(authzConfig.AuthorizationPolicyFile)
 			if err != nil {
 				return nil, err
 			}
 			authorizers = append(authorizers, abacAuthorizer)
 		case ModeKeystone:
-			keystoneAuthorizer, err := keystone.NewKeystoneAuthorizer(kubeClient)
+			if authzConfig.KeystonAuthURL == "" {
+				return nil, errors.New("Cannot use mode Keystone without specifying --experimental-keystone-url")
+			}
+			keystoneAuthorizer, err := keystone.NewKeystoneAuthorizer(authzConfig.KubeClient, authzConfig.KeystonAuthURL)
 			if err != nil {
 				return nil, err
 			}
@@ -111,8 +121,11 @@ func NewAuthorizerFromAuthorizationConfig(authorizationModes []string, authoriza
 		authorizerMap[authorizationMode] = true
 	}
 
-	if !authorizerMap[ModeABAC] && !authorizerMap[ModeKeystone] && authorizationPolicyFile != "" {
+	if !authorizerMap[ModeABAC] && authzConfig.AuthorizationPolicyFile != "" {
 		return nil, errors.New("Cannot specify --authorization-policy-file without mode ABAC")
+	}
+	if !authorizerMap[ModeKeystone] && authzConfig.KeystonAuthURL != "" {
+		return nil, errors.New("Cannot specify --experimental-keystone-url without mode Keystone")
 	}
 
 	return union.New(authorizers...), nil

--- a/pkg/apiserver/handlers.go
+++ b/pkg/apiserver/handlers.go
@@ -378,6 +378,8 @@ func (r *requestAttributeGetter) GetAttribs(req *http.Request) authorizer.Attrib
 
 	attribs.Tenant = apiRequestInfo.Tenant
 
+	attribs.Network = apiRequestInfo.Network
+
 	return &attribs
 }
 
@@ -405,6 +407,7 @@ type APIRequestInfo struct {
 	APIVersion string
 	Namespace  string
 	Tenant     string
+	Network    string
 	// Resource is the name of the resource being requested.  This is not the kind.  For example: pods
 	Resource string
 	// Subresource is the name of the subresource being requested.  This is a different resource, scoped to the parent resource, but it may have a different kind.
@@ -501,7 +504,8 @@ func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIReques
 	}
 
 	// URL forms: /namespaces/{namespace}/{kind}/*, where parts are adjusted to be relative to kind
-	if currentParts[0] == "namespaces" {
+	part0 := currentParts[0]
+	if part0 == "namespaces" {
 		if len(currentParts) > 1 {
 			requestInfo.Namespace = currentParts[1]
 
@@ -514,7 +518,20 @@ func (r *APIRequestInfoResolver) GetAPIRequestInfo(req *http.Request) (APIReques
 	} else {
 		requestInfo.Namespace = api.NamespaceNone
 	}
-	if currentParts[0] == "tenants" {
+	if part0 == "networks" {
+		if len(currentParts) > 1 {
+			requestInfo.Network = currentParts[1]
+
+			// if there is another step after the network name and it is not a known network subresource
+			// move currentParts to include it as a resource in its own right
+			if len(currentParts) > 2 {
+				currentParts = currentParts[2:]
+			}
+		}
+	} else {
+		requestInfo.Network = api.NetworkNone
+	}
+	if part0 == "tenants" {
 		if len(currentParts) > 1 {
 			requestInfo.Tenant = currentParts[1]
 

--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -132,13 +132,13 @@ func (p policy) subjectMatches(a authorizer.Attributes) bool {
 }
 
 // Authorizer implements authorizer.Authorize
-func (pl policyList) Authorize(a authorizer.Attributes) error {
+func (pl policyList) Authorize(a authorizer.Attributes) (string, error) {
 	for _, p := range pl {
 		if p.matches(a) {
-			return nil
+			return "", nil
 		}
 	}
-	return errors.New("No policy matched.")
+	return "", errors.New("No policy matched.")
 	// TODO: Benchmark how much time policy matching takes with a medium size
 	// policy file, compared to other steps such as encoding/decoding.
 	// Then, add Caching only if needed.

--- a/pkg/auth/authorizer/interfaces.go
+++ b/pkg/auth/authorizer/interfaces.go
@@ -52,6 +52,9 @@ type Attributes interface {
 	// The namespace of the object, if a request is for a REST object.
 	GetNamespace() string
 
+	// The network
+	GetNetwork() string
+
 	// The kind of object, if a request is for a REST object.
 	GetResource() string
 
@@ -78,6 +81,7 @@ type AttributesRecord struct {
 	Verb      string
 	Tenant    string
 	Namespace string
+	Network   string
 	APIGroup  string
 	Resource  string
 }
@@ -112,6 +116,10 @@ func (a AttributesRecord) GetTenant() string {
 
 func (a AttributesRecord) GetNamespace() string {
 	return a.Namespace
+}
+
+func (a AttributesRecord) GetNetwork() string {
+	return a.Network
 }
 
 func (a AttributesRecord) GetResource() string {

--- a/pkg/auth/authorizer/interfaces.go
+++ b/pkg/auth/authorizer/interfaces.go
@@ -63,12 +63,12 @@ type Attributes interface {
 // zero or more calls to methods of the Attributes interface.  It returns nil when an action is
 // authorized, otherwise it returns an error.
 type Authorizer interface {
-	Authorize(a Attributes) (err error)
+	Authorize(a Attributes) (tenant string, err error)
 }
 
-type AuthorizerFunc func(a Attributes) error
+type AuthorizerFunc func(a Attributes) (string, error)
 
-func (f AuthorizerFunc) Authorize(a Attributes) error {
+func (f AuthorizerFunc) Authorize(a Attributes) (string, error) {
 	return f(a)
 }
 

--- a/pkg/auth/authorizer/keystone/keystone.go
+++ b/pkg/auth/authorizer/keystone/keystone.go
@@ -31,11 +31,6 @@ import (
 	"github.com/rackspace/gophercloud/pagination"
 )
 
-const (
-	ADMIN_URL = "http://127.0.0.1:35357/v2.0"
-	USER_URL  = "http://127.0.0.1:5000/v2.0"
-)
-
 type authConfig struct {
 	AuthUrl  string `json:"auth-url"`
 	Username string `json:"user-name"`
@@ -54,6 +49,7 @@ type OpenstackClient struct {
 type keystoneAuthorizer struct {
 	kubeClient client.Interface
 	osClient   OpenstackInterface
+	authUrl    string
 }
 
 func newOpenstackClient(config *authConfig) (*OpenstackClient, error) {
@@ -86,10 +82,11 @@ func newOpenstackClient(config *authConfig) (*OpenstackClient, error) {
 	}, nil
 }
 
-func NewKeystoneAuthorizer(kubeClient client.Interface) (*keystoneAuthorizer, error) {
+func NewKeystoneAuthorizer(kubeClient client.Interface, authUrl string) (*keystoneAuthorizer, error) {
 
 	ka := &keystoneAuthorizer{
 		kubeClient: kubeClient,
+		authUrl:    authUrl,
 	}
 	return ka, nil
 }
@@ -109,7 +106,7 @@ func (ka *keystoneAuthorizer) Authorize(a authorizer.Attributes) (string, error)
 	}
 
 	authConfig := &authConfig{
-		AuthUrl:  USER_URL,
+		AuthUrl:  ka.authUrl,
 		Username: a.GetUserName(),
 		Password: a.GetPassword(),
 	}

--- a/pkg/auth/authorizer/keystone/keystone.go
+++ b/pkg/auth/authorizer/keystone/keystone.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"strings"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/auth/authorizer"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 
@@ -27,8 +28,12 @@ import (
 	"github.com/rackspace/gophercloud"
 	"github.com/rackspace/gophercloud/openstack"
 	"github.com/rackspace/gophercloud/openstack/identity/v2/tenants"
-	"github.com/rackspace/gophercloud/openstack/identity/v2/users"
 	"github.com/rackspace/gophercloud/pagination"
+)
+
+const (
+	ADMIN_URL = "http://127.0.0.1:35357/v2.0"
+	USER_URL  = "http://127.0.0.1:5000/v2.0"
 )
 
 type authConfig struct {
@@ -37,6 +42,7 @@ type authConfig struct {
 	Password string `json:"password"`
 	TokenID  string `json:"token"`
 	Tenant   string `json:"tenant"`
+	TenantID string `json:"tenantID"`
 }
 
 type OpenstackClient struct {
@@ -62,8 +68,8 @@ func newOpenstackClient(config *authConfig) (*OpenstackClient, error) {
 		Username:         config.Username,
 		Password:         config.Password,
 		TenantName:       config.Tenant,
-		//TokenID:     config.TokenID,
-		AllowReauth: true,
+		TenantID:         config.TenantID,
+		AllowReauth:      false,
 	}
 
 	provider, err := openstack.AuthenticatedClient(opts)
@@ -89,82 +95,53 @@ func NewKeystoneAuthorizer(kubeClient client.Interface) (*keystoneAuthorizer, er
 }
 
 // Authorizer implements authorizer.Authorize
-func (ka *keystoneAuthorizer) Authorize(a authorizer.Attributes) error {
+func (ka *keystoneAuthorizer) Authorize(a authorizer.Attributes) (string, error) {
 
 	var (
-		tenantID string
-		userID   string
+		tenantName string
+		ns         *api.Namespace
 	)
 	if strings.HasPrefix(a.GetUserName(), "system:serviceaccount:") {
-		return nil
+		return "", nil
 	}
 	if isWhiteListedUser(a.GetUserName()) {
-		return nil
+		return "", nil
 	}
-	ns, err := ka.kubeClient.Namespaces().Get(a.GetNamespace())
-	if err != nil {
-		return err
-	}
+
 	authConfig := &authConfig{
-		AuthUrl:  "http://127.0.0.1:35357/v2.0",
+		AuthUrl:  USER_URL,
 		Username: a.GetUserName(),
 		Password: a.GetPassword(),
-		TokenID:  a.GetToken(),
-		Tenant:   ns.Tenant,
 	}
-	osClient, err1 := newOpenstackClient(authConfig)
-	if err1 != nil {
-		glog.Errorf("%v", err1)
-		return err1
-	}
-	tenantID, err = osClient.getTenantID(ns.Tenant)
+	osClient, err := newOpenstackClient(authConfig)
 	if err != nil {
 		glog.Errorf("%v", err)
-		return err
+		return "", err
 	}
-	userID, err = osClient.getUserID(a.GetUserName())
-	if err != nil {
-		glog.Errorf("%v", err)
-		return err
-	}
-	hasRole, err := osClient.roleCheck(userID, tenantID)
-	if err != nil {
-		glog.V(4).Infof("Keystone authorization failed: %v", err)
-		return errors.New("Keystone authorization failed")
-	}
-	if hasRole {
-		return nil
-	} else {
-		return errors.New("User not authorized through keystone for namespace")
-	}
-	return errors.New("Keystone authorization failed")
-}
-
-// Checks if a user has access to a tenant
-func (osClient *OpenstackClient) roleCheck(userID string, tenantID string) (bool, error) {
-	if userID == "" {
-		return false, errors.New("UserID null during authorization")
-	}
-	if tenantID == "" {
-		return false, errors.New("UserID null during authorization")
-	}
-	hasRole := false
-	pager := users.ListRoles(osClient.authClient, tenantID, userID)
-	err := pager.EachPage(func(page pagination.Page) (bool, error) {
-		roleList, err := users.ExtractRoles(page)
+	if a.GetNamespace() != "" {
+		ns, err = ka.kubeClient.Namespaces().Get(a.GetNamespace())
 		if err != nil {
-			return false, err
+			return "", err
 		}
-		if len(roleList) > 0 {
-			hasRole = true
+		tenantName = ns.Tenant
+	} else {
+		if a.GetTenant() != "" {
+			te, err := ka.kubeClient.Tenants().Get(a.GetTenant())
+			if err != nil {
+				return "", err
+			}
+			tenantName = te.Name
 		}
-		return true, nil
-	})
-
-	if err != nil {
-		return false, err
 	}
-	return hasRole, nil
+	tenant, err := osClient.getTenant()
+	if err != nil {
+		glog.Errorf("%v", err)
+		return "", err
+	}
+	if tenantName == "" || tenantName == tenant.Name {
+		return tenant.Name, nil
+	}
+	return "", errors.New("Keystone authorization failed")
 }
 
 func isWhiteListedUser(username string) bool {
@@ -179,7 +156,7 @@ func isWhiteListedUser(username string) bool {
 	return whiteList[username]
 }
 
-func (osClient *OpenstackClient) getTenantID(name string) (id string, err error) {
+func (osClient *OpenstackClient) getTenant() (tenant *tenants.Tenant, err error) {
 	tenantList := make([]tenants.Tenant, 0)
 	opts := tenants.ListOpts{}
 	pager := tenants.List(osClient.authClient, &opts)
@@ -191,33 +168,12 @@ func (osClient *OpenstackClient) getTenantID(name string) (id string, err error)
 		return true, nil
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	for _, t := range tenantList {
-		if name == t.Name {
-			return t.ID, nil
-		}
+	if len(tenantList) > 1 {
+		return nil, errors.New("too much tenants")
+	} else if len(tenantList) != 1 {
+		return nil, errors.New("no tenants")
 	}
-	return "", nil
-}
-
-func (osClient *OpenstackClient) getUserID(name string) (id string, err error) {
-	userList := make([]users.User, 0)
-	pager := users.List(osClient.authClient)
-	err = pager.EachPage(func(page pagination.Page) (bool, error) {
-		userList, err = users.ExtractUsers(page)
-		if err != nil {
-			return false, err
-		}
-		return true, nil
-	})
-	if err != nil {
-		return "", err
-	}
-	for _, u := range userList {
-		if name == u.Name {
-			return u.ID, nil
-		}
-	}
-	return "", nil
+	return &tenantList[0], nil
 }

--- a/pkg/auth/authorizer/keystone/types.go
+++ b/pkg/auth/authorizer/keystone/types.go
@@ -16,9 +16,11 @@ limitations under the License.
 
 package keystone
 
+import (
+	"github.com/rackspace/gophercloud/openstack/identity/v2/tenants"
+)
+
 // Interface is an abstract interface for testability.  It abstracts the interface to Keystone.
 type OpenstackInterface interface {
-	roleCheck(string, string) (bool, error)
-	getTenantID(string) (string, error)
-	getUserID(string) (string, error)
+	getTenant() (*tenants.Tenant, error)
 }

--- a/pkg/auth/authorizer/union/union.go
+++ b/pkg/auth/authorizer/union/union.go
@@ -30,16 +30,16 @@ func New(authorizationHandlers ...authorizer.Authorizer) authorizer.Authorizer {
 }
 
 // Authorizes against a chain of authorizer.Authorizer objects and returns nil if successful and returns error if unsuccessful
-func (authzHandler unionAuthzHandler) Authorize(a authorizer.Attributes) error {
+func (authzHandler unionAuthzHandler) Authorize(a authorizer.Attributes) (string, error) {
 	var errlist []error
 	for _, currAuthzHandler := range authzHandler {
-		err := currAuthzHandler.Authorize(a)
+		tenant, err := currAuthzHandler.Authorize(a)
 		if err != nil {
 			errlist = append(errlist, err)
 			continue
 		}
-		return nil
+		return tenant, nil
 	}
 
-	return errors.NewAggregate(errlist)
+	return "", errors.NewAggregate(errlist)
 }

--- a/pkg/auth/user/user.go
+++ b/pkg/auth/user/user.go
@@ -34,6 +34,9 @@ type Info interface {
 	GetUID() string
 	// GetGroups returns the names of the groups the user is a member of
 	GetGroups() []string
+
+	// GetTenant returns the tenant of the user
+	GetTenant() string
 }
 
 // DefaultInfo provides a simple user information exchange object
@@ -44,6 +47,7 @@ type DefaultInfo struct {
 	Token    string
 	UID      string
 	Groups   []string
+	Tenant   string
 }
 
 func (i *DefaultInfo) GetName() string {
@@ -64,4 +68,8 @@ func (i *DefaultInfo) GetUID() string {
 
 func (i *DefaultInfo) GetGroups() []string {
 	return i.Groups
+}
+
+func (i *DefaultInfo) GetTenant() string {
+	return i.Tenant
 }

--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -51,6 +51,9 @@ type ClientConfig interface {
 	// result of all overrides and a boolean indicating if it was
 	// overridden
 	Namespace() (string, bool, error)
+	// Tenant returns the tenant resulting from the merged
+	// result of all overrides and a boolean indicating if it was
+	// overridden
 	Tenant() (string, bool, error)
 }
 

--- a/pkg/client/unversioned/clientcmd/validation.go
+++ b/pkg/client/unversioned/clientcmd/validation.go
@@ -232,6 +232,10 @@ func validateContext(contextName string, context clientcmdapi.Context, config cl
 		validationErrors = append(validationErrors, fmt.Errorf("cluster %q was not found for context %q", context.Cluster, contextName))
 	}
 
+	if (len(context.Tenant) != 0) && !validation.IsDNS952Label(context.Tenant) {
+		validationErrors = append(validationErrors, fmt.Errorf("tenant %q for context %q does not conform to the kubernetes DNS952 rules", context.Tenant, contextName))
+	}
+
 	if (len(context.Namespace) != 0) && !validation.IsDNS952Label(context.Namespace) {
 		validationErrors = append(validationErrors, fmt.Errorf("namespace %q for context %q does not conform to the kubernetes DNS952 rules", context.Namespace, contextName))
 	}

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -269,8 +269,13 @@ func syncTenantAndNamespace(kubeClient client.Interface, namespace *api.Namespac
 	}
 	te.Spec.Namespaces = append(te.Spec.Namespaces, *namespace)
 
-	_, err = kubeClient.Tenants().Update(te)
-	return err
+	if _, err = kubeClient.Namespaces().Update(namespace); err != nil {
+		return err
+	}
+	if _, err = kubeClient.Tenants().Update(te); err != nil {
+		return err
+	}
+	return nil
 }
 
 // syncNamespace orchestrates deletion of a Namespace and its associated content.

--- a/pkg/fieldpath/fieldpath.go
+++ b/pkg/fieldpath/fieldpath.go
@@ -54,6 +54,8 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 		return accessor.Name(), nil
 	case "metadata.namespace":
 		return accessor.Namespace(), nil
+	case "metadata.tenant":
+		return accessor.Tenant(), nil
 	}
 
 	return "", fmt.Errorf("Unsupported fieldPath: %v", fieldPath)

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -110,6 +110,10 @@ func (o *AnnotateOptions) Complete(f *cmdutil.Factory, args []string) (err error
 	if err != nil {
 		return err
 	}
+	tenant, enforceTenant, errT := f.DefaultTenant()
+	if errT != nil {
+		return errT
+	}
 
 	// retrieves resource and annotation args from args
 	// also checks args to verify that all resources are specified before annotations
@@ -144,7 +148,8 @@ func (o *AnnotateOptions) Complete(f *cmdutil.Factory, args []string) (err error
 	o.builder = resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, o.filenames...).
+		TenantParam(tenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, o.filenames...).
 		ResourceTypeOrNameArgs(o.all, o.resources...).
 		Flatten().
 		Latest()

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -87,13 +87,17 @@ func RunCreate(f *cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *C
 	if err != nil {
 		return err
 	}
-
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		TenantParam(cmdTenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		Flatten().
 		Do()
 	err = r.Err()

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -106,12 +106,17 @@ func RunDelete(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 	deleteAll := cmdutil.GetFlagBool(cmd, "all")
 	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		TenantParam(cmdTenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(deleteAll).
 		ResourceTypeOrNameArgs(false, args...).RequireObject(false).

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -99,6 +99,10 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 	if len(args) == 0 && len(options.Filenames) == 0 {
 		fmt.Fprint(out, "You must specify the type of resource to describe. ", valid_resources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
@@ -108,7 +112,8 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		TenantParam(cmdTenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		SelectorParam(selector).
 		ResourceTypeOrNameArgs(true, args...).
 		Flatten().

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -112,6 +112,10 @@ func RunEdit(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	mapper, typer := f.Object()
 	rmap := &resource.Mapper{
@@ -122,7 +126,8 @@ func RunEdit(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, filenames...).
+		TenantParam(cmdTenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, filenames...).
 		ResourceTypeOrNameArgs(true, args...).
 		Latest().
 		Flatten().

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -99,12 +99,17 @@ func RunExpose(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 	if err != nil {
 		return err
 	}
+	tenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		TenantParam(tenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		ResourceTypeOrNameArgs(false, args...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -118,6 +118,10 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	if len(args) == 0 && len(options.Filenames) == 0 {
 		fmt.Fprint(out, "You must specify the type of resource to get. ", valid_resources, `   * componentstatuses (aka 'cs')
@@ -131,7 +135,8 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 	if isWatch || isWatchOnly {
 		r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 			NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
-			FilenameParam(enforceNamespace, options.Filenames...).
+			TenantParam(cmdTenant).DefaultTenant().
+			FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 			SelectorParam(selector).
 			ResourceTypeOrNameArgs(true, args...).
 			SingleResourceType().
@@ -185,7 +190,7 @@ func RunGet(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string
 
 	b := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
-		FilenameParam(enforceNamespace, options.Filenames...).
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		SelectorParam(selector).
 		ResourceTypeOrNameArgs(true, args...).
 		ContinueOnError().

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -192,6 +192,10 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	lbls, remove, err := parseLabels(labelArgs)
 	if err != nil {
@@ -201,7 +205,8 @@ func RunLabel(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	b := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		TenantParam(cmdTenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		SelectorParam(selector).
 		ResourceTypeOrNameArgs(all, resources...).
 		Flatten().

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -81,6 +81,10 @@ func RunPatch(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	patch := cmdutil.GetFlagString(cmd, "patch")
 	if len(patch) == 0 {
@@ -95,7 +99,8 @@ func RunPatch(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		TenantParam(cmdTenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		ResourceTypeOrNameArgs(false, args...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -99,6 +99,10 @@ func RunReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []st
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	force := cmdutil.GetFlagBool(cmd, "force")
 	if len(options.Filenames) == 0 {
@@ -115,7 +119,8 @@ func RunReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []st
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		TenantParam(cmdTenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		Flatten().
 		Do()
 	err = r.Err()
@@ -173,7 +178,7 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		ResourceTypeOrNameArgs(false, args...).RequireObject(false).
 		Flatten().
 		Do()
@@ -198,7 +203,7 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		Flatten().
 		Do()
 	err = r.Err()

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -157,6 +157,10 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	for i, filename := range options.Filenames {
 		if filename == "-" {
@@ -178,6 +182,7 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
+		TenantParam(cmdTenant).DefaultTenant().
 		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		ResourceTypeOrNameArgs(false, args...).RequireObject(false).
 		Flatten().
@@ -203,6 +208,7 @@ func forceReplace(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
+		TenantParam(cmdTenant).DefaultTenant().
 		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -145,6 +145,10 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	client, err := f.Client()
 	if err != nil {
@@ -180,7 +184,8 @@ func RunRollingUpdate(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, arg
 		request := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 			Schema(schema).
 			NamespaceParam(cmdNamespace).DefaultNamespace().
-			FilenameParam(enforceNamespace, filename).
+			TenantParam(cmdTenant).DefaultTenant().
+			FilenameParam(enforceTenant, enforceNamespace, filename).
 			Do()
 		obj, err := request.Object()
 		if err != nil {

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -100,12 +100,17 @@ func RunScale(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, options.Filenames...).
+		TenantParam(cmdTenant).DefaultTenant().
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		ResourceTypeOrNameArgs(false, args...).
 		Flatten().
 		Do()

--- a/pkg/kubectl/cmd/stop.go
+++ b/pkg/kubectl/cmd/stop.go
@@ -81,13 +81,18 @@ func RunStop(f *cmdutil.Factory, cmd *cobra.Command, args []string, out io.Write
 	if err != nil {
 		return err
 	}
+	cmdTenant, enforceTenant, err := f.DefaultTenant()
+	if err != nil {
+		return err
+	}
 
 	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
+		TenantParam(cmdTenant).DefaultTenant().
 		ResourceTypeOrNameArgs(false, args...).
-		FilenameParam(enforceNamespace, options.Filenames...).
+		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		SelectorParam(cmdutil.GetFlagString(cmd, "selector")).
 		SelectAllParam(cmdutil.GetFlagBool(cmd, "all")).
 		Flatten().

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -86,6 +86,10 @@ type Factory struct {
 	// other namespace is specified and whether the namespace was
 	// overriden.
 	DefaultNamespace func() (string, bool, error)
+	// Returns the default tenant to use in cases where no
+	// other tenant is specified and whether the tenant was
+	// overriden.
+	DefaultTenant func() (string, bool, error)
 	// Returns the generator for the provided generator name
 	Generator func(name string) (kubectl.Generator, bool)
 	// Check whether the kind of resources could be exposed
@@ -245,6 +249,9 @@ func NewFactory(optionalClientConfig clientcmd.ClientConfig) *Factory {
 		},
 		DefaultNamespace: func() (string, bool, error) {
 			return clientConfig.Namespace()
+		},
+		DefaultTenant: func() (string, bool, error) {
+			return clientConfig.Tenant()
 		},
 		Generator: func(name string) (kubectl.Generator, bool) {
 			generator, ok := generators[name]

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -136,6 +136,7 @@ func init() {
 		describeDaemonSet,
 		describeNode,
 		describeNamespace,
+		describeTenant,
 	)
 	if err != nil {
 		glog.Fatalf("Cannot register describers: %v", err)
@@ -237,6 +238,7 @@ func (d *NamespaceDescriber) Describe(namespace, name string) (string, error) {
 func describeNamespace(namespace *api.Namespace, resourceQuotaList *api.ResourceQuotaList, limitRangeList *api.LimitRangeList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		fmt.Fprintf(out, "Name:\t%s\n", namespace.Name)
+		fmt.Fprintf(out, "Tenant:\t%s\n", namespace.Tenant)
 		fmt.Fprintf(out, "Network:\t%s\n", namespace.Spec.Network)
 		fmt.Fprintf(out, "Labels:\t%s\n", labels.FormatLabels(namespace.Labels))
 		fmt.Fprintf(out, "Status:\t%s\n", string(namespace.Status.Phase))

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -179,7 +179,7 @@ func (v *testVisitor) Objects() []runtime.Object {
 
 func TestPathBuilder(t *testing.T) {
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
-		FilenameParam(false, "../../../examples/guestbook/redis-master-controller.yaml")
+		FilenameParam(false, false, "../../../examples/guestbook/redis-master-controller.yaml")
 
 	test := &testVisitor{}
 	singular := false
@@ -229,8 +229,8 @@ func TestNodeBuilder(t *testing.T) {
 
 func TestPathBuilderWithMultiple(t *testing.T) {
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
-		FilenameParam(false, "../../../examples/guestbook/redis-master-controller.yaml").
-		FilenameParam(false, "../../../examples/pod").
+		FilenameParam(false, false, "../../../examples/guestbook/redis-master-controller.yaml").
+		FilenameParam(false, false, "../../../examples/pod").
 		NamespaceParam("test").DefaultNamespace()
 
 	test := &testVisitor{}
@@ -253,7 +253,7 @@ func TestPathBuilderWithMultiple(t *testing.T) {
 
 func TestDirectoryBuilder(t *testing.T) {
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
-		FilenameParam(false, "../../../examples/guestbook").
+		FilenameParam(false, false, "../../../examples/guestbook").
 		NamespaceParam("test").DefaultNamespace()
 
 	test := &testVisitor{}
@@ -283,7 +283,7 @@ func TestNamespaceOverride(t *testing.T) {
 	defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
-		FilenameParam(false, s.URL).
+		FilenameParam(false, false, s.URL).
 		NamespaceParam("test")
 
 	test := &testVisitor{}
@@ -294,7 +294,7 @@ func TestNamespaceOverride(t *testing.T) {
 	}
 
 	b = NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
-		FilenameParam(true, s.URL).
+		FilenameParam(false, true, s.URL).
 		NamespaceParam("test")
 
 	test = &testVisitor{}
@@ -313,7 +313,7 @@ func TestURLBuilder(t *testing.T) {
 	defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
-		FilenameParam(false, s.URL).
+		FilenameParam(false, false, s.URL).
 		NamespaceParam("test")
 
 	test := &testVisitor{}
@@ -337,7 +337,7 @@ func TestURLBuilderRequireNamespace(t *testing.T) {
 	defer s.Close()
 
 	b := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
-		FilenameParam(false, s.URL).
+		FilenameParam(false, false, s.URL).
 		NamespaceParam("test").RequireNamespace()
 
 	test := &testVisitor{}
@@ -841,7 +841,7 @@ func TestContinueOnErrorVisitor(t *testing.T) {
 func TestSingularObject(t *testing.T) {
 	obj, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
 		NamespaceParam("test").DefaultNamespace().
-		FilenameParam(false, "../../../examples/guestbook/redis-master-controller.yaml").
+		FilenameParam(false, false, "../../../examples/guestbook/redis-master-controller.yaml").
 		Flatten().
 		Do().Object()
 
@@ -861,7 +861,7 @@ func TestSingularObject(t *testing.T) {
 func TestSingularObjectNoExtension(t *testing.T) {
 	obj, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
 		NamespaceParam("test").DefaultNamespace().
-		FilenameParam(false, "../../../examples/pod").
+		FilenameParam(false, false, "../../../examples/pod").
 		Flatten().
 		Do().Object()
 
@@ -972,7 +972,7 @@ func TestWatch(t *testing.T) {
 		}),
 	})).
 		NamespaceParam("test").DefaultNamespace().
-		FilenameParam(false, "../../../examples/guestbook/redis-master-service.yaml").Flatten().
+		FilenameParam(false, false, "../../../examples/guestbook/redis-master-service.yaml").Flatten().
 		Do().Watch("12")
 
 	if err != nil {
@@ -999,8 +999,8 @@ func TestWatch(t *testing.T) {
 func TestWatchMultipleError(t *testing.T) {
 	_, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient()).
 		NamespaceParam("test").DefaultNamespace().
-		FilenameParam(false, "../../../examples/guestbook/redis-master-controller.yaml").Flatten().
-		FilenameParam(false, "../../../examples/guestbook/redis-master-controller.yaml").Flatten().
+		FilenameParam(false, false, "../../../examples/guestbook/redis-master-controller.yaml").Flatten().
+		FilenameParam(false, false, "../../../examples/guestbook/redis-master-controller.yaml").Flatten().
 		Do().Watch("")
 
 	if err == nil {

--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -68,6 +68,7 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 	}
 	name, _ := mapping.MetadataAccessor.Name(obj)
 	namespace, _ := mapping.MetadataAccessor.Namespace(obj)
+	tenant, _ := mapping.MetadataAccessor.Tenant(obj)
 	resourceVersion, _ := mapping.MetadataAccessor.ResourceVersion(obj)
 
 	var versionedObject interface{}
@@ -79,6 +80,7 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 		Mapping:         mapping,
 		Client:          client,
 		Namespace:       namespace,
+		Tenant:          tenant,
 		Name:            name,
 		Source:          source,
 		VersionedObject: versionedObject,
@@ -88,7 +90,7 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 }
 
 // InfoForObject creates an Info object for the given Object. An error is returned
-// if the object cannot be introspected. Name and namespace will be set into Info
+// if the object cannot be introspected. Name, namespace and tenant will be set into Info
 // if the mapping's MetadataAccessor can retrieve them.
 func (m *Mapper) InfoForObject(obj runtime.Object) (*Info, error) {
 	version, kind, err := m.ObjectVersionAndKind(obj)
@@ -105,11 +107,13 @@ func (m *Mapper) InfoForObject(obj runtime.Object) (*Info, error) {
 	}
 	name, _ := mapping.MetadataAccessor.Name(obj)
 	namespace, _ := mapping.MetadataAccessor.Namespace(obj)
+	tenant, _ := mapping.MetadataAccessor.Tenant(obj)
 	resourceVersion, _ := mapping.MetadataAccessor.ResourceVersion(obj)
 	return &Info{
 		Mapping:   mapping,
 		Client:    client,
 		Namespace: namespace,
+		Tenant:    tenant,
 		Name:      name,
 
 		Object:          obj,

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -398,7 +398,7 @@ var eventColumns = []string{"FIRSTSEEN", "LASTSEEN", "COUNT", "NAME", "KIND", "S
 var limitRangeColumns = []string{"NAME", "AGE"}
 var resourceQuotaColumns = []string{"NAME", "AGE"}
 var tenantColumns = []string{"NAME", "LABELS", "STATUS", "AGE"}
-var namespaceColumns = []string{"NAME", "LABELS", "STATUS", "AGE"}
+var namespaceColumns = []string{"NAME", "LABELS", "TENANT", "STATUS", "AGE"}
 var networkColumns = []string{"NAME", "SUBNETS", "PROVIDERNETWORKID", "TENANT", "LABELS", "STATUS"}
 var secretColumns = []string{"NAME", "TYPE", "DATA", "AGE"}
 var serviceAccountColumns = []string{"NAME", "SECRETS", "AGE"}
@@ -1013,7 +1013,7 @@ func printNamespace(item *api.Namespace, w io.Writer, withNamespace bool, wide b
 		return fmt.Errorf("namespace is not namespaced")
 	}
 
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s", item.Name, labels.FormatLabels(item.Labels), item.ObjectMeta.Tenant, item.Status.Phase, translateTimestamp(item.CreationTimestamp)); err != nil {
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s", item.Name, labels.FormatLabels(item.Labels), item.Tenant, item.Status.Phase, translateTimestamp(item.CreationTimestamp)); err != nil {
 		return err
 	}
 	_, err := fmt.Fprint(w, appendLabels(item.Labels, columnLabels))

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -741,7 +741,7 @@ func (m *Master) init(c *Config) {
 	m.InsecureHandler = handler
 
 	attributeGetter := apiserver.NewRequestAttributeGetter(m.requestContextMapper, m.newAPIRequestInfoResolver())
-	handler = apiserver.WithAuthorizationCheck(handler, attributeGetter, m.authorizer)
+	handler = apiserver.WithAuthorizationCheck(handler, attributeGetter, m.authorizer, m.requestContextMapper)
 
 	// Install Authenticator
 	if c.Authenticator != nil {

--- a/pkg/registry/namespace/strategy.go
+++ b/pkg/registry/namespace/strategy.go
@@ -148,8 +148,9 @@ func MatchNamespace(label labels.Selector, field fields.Selector) generic.Matche
 // NamespaceToSelectableFields returns a label set that represents the object
 func NamespaceToSelectableFields(namespace *api.Namespace) labels.Set {
 	return labels.Set{
-		"metadata.name": namespace.Name,
-		"status.phase":  string(namespace.Status.Phase),
+		"metadata.name":   namespace.Name,
+		"metadata.tenant": namespace.Tenant,
+		"status.phase":    string(namespace.Status.Phase),
 		// This is a bug, but we need to support it for backward compatibility.
 		"name": namespace.Name,
 	}

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -135,6 +135,8 @@ type SelfLinker interface {
 	Namespace(obj Object) (string, error)
 	// Knowing Tenant
 	Tenant(obj Object) (string, error)
+	// Set tenant of object
+	SetTenant(obj Object, tenant string) error
 }
 
 // All api types must support the Object interface. It's deliberately tiny so that this is not an onerous

--- a/pkg/runtime/interfaces.go
+++ b/pkg/runtime/interfaces.go
@@ -133,6 +133,8 @@ type SelfLinker interface {
 	Name(obj Object) (string, error)
 	// Knowing Namespace is sometimes necessary to use a SelfLinker
 	Namespace(obj Object) (string, error)
+	// Knowing Tenant
+	Tenant(obj Object) (string, error)
 }
 
 // All api types must support the Object interface. It's deliberately tiny so that this is not an onerous


### PR DESCRIPTION
Commits(https://github.com/hyperhq/hypernetes/commit/bd154254746767c8666721b117de1be758711c9c, https://github.com/hyperhq/hypernetes/commit/877dbbbe1582d001577b0aee71341f62107168cc and https://github.com/hyperhq/hypernetes/commit/bcdf7b57fa4e399aceda666da20d6fcf839f1b93) are under review in https://github.com/hyperhq/hypernetes/pull/9, this new commit(https://github.com/hyperhq/hypernetes/commit/5aa5b85f07101ced5d4f9089267c4de9c9396793) is based on them.  So I combine them together to test.
##### Test Result

```
lei@ubuntu:~/src/k8s.io/kubernetes$ curl -i -k -X POST -H "Authorization: Basic dGVzdDp0ZXN0" https://127.0.0.1:6443/api/v1/networks -d "$(cat /tmp/my-network.json)"
HTTP/1.1 201 Created
Content-Type: application/json
Date: Tue, 20 Oct 2015 07:17:51 GMT
Content-Length: 503

{
  "kind": "Network",
  "apiVersion": "v1",
  "metadata": {
    "name": "demo",
    "tenant": "test",
    "selfLink": "/api/v1/networks/demo",
    "uid": "ac5fc5a6-76fa-11e5-97d1-000c2986b7f9",
    "resourceVersion": "23",
    "creationTimestamp": "2015-10-20T07:17:51Z",
    "labels": {
      "name": "demo"
    }
  },
  "spec": {
    "subnets": {
      "subnet1": {
        "cidr": "192.168.0.0/24",
        "gateway": "192.168.0.1"
      }
    }
  },
  "status": {
    "phase": "Initializing"
  }
}
lei@ubuntu:~/src/k8s.io/kubernetes$ kubectl get tenants
NAME      LABELS            STATUS    AGE
default   <none>            Active    1m
test      name=production   Active    33s
lei@ubuntu:~/src/k8s.io/kubernetes$ kubectl get networks
NAME      SUBNETS          PROVIDERNETWORKID   TENANT    LABELS      STATUS
demo      192.168.0.0/24                       test      name=demo   Initializing
lei@ubuntu:~/src/k8s.io/kubernetes$ kubectl create -f /^C
lei@ubuntu:~/src/k8s.io/kubernetes$ vim /tmp/my-network.json
lei@ubuntu:~/src/k8s.io/kubernetes$ kubectl create -f /tmp/my-network.json
network "dev" created
lei@ubuntu:~/src/k8s.io/kubernetes$ kubectl get networks
NAME      SUBNETS          PROVIDERNETWORKID   TENANT    LABELS      STATUS
demo      192.168.0.0/24                       test      name=demo   Initializing
dev       192.168.0.0/24                       default   name=demo   Initializing
lei@ubuntu:~/src/k8s.io/kubernetes$ kubectl get networks --username=test --password=test
NAME      SUBNETS          PROVIDERNETWORKID   TENANT    LABELS      STATUS
demo      192.168.0.0/24                       test      name=demo   Initializing
lei@ubuntu:~/src/k8s.io/kubernetes$
```
