### PR TITLE
add tenant metadata for replicationcontroller and it's pods

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -283,12 +283,22 @@ func (r RealPodControl) createPods(nodeName, namespace string, template *api.Pod
 		return fmt.Errorf("object does not have ObjectMeta, %v", err)
 	}
 	prefix := getPodsPrefix(meta.Name)
+	tenant := meta.Tenant
+	if tenant == "" {
+		ns, err := r.KubeClient.Namespaces().Get(namespace)
+		if err != nil {
+			glog.Error(err)
+			return err
+		}
+		tenant = ns.Tenant
+	}
 
 	pod := &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Labels:       desiredLabels,
 			Annotations:  desiredAnnotations,
 			GenerateName: prefix,
+			Tenant:       tenant,
 		},
 	}
 	if err := api.Scheme.Convert(&template.Spec, &pod.Spec); err != nil {

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -428,6 +428,12 @@ func (rm *ReplicationManager) syncReplicationController(key string) error {
 		rm.enqueueController(&rc)
 		return nil
 	}
+	ns, err := rm.kubeClient.Namespaces().Get(rc.Namespace)
+	if err != nil {
+		glog.Error(err)
+		return err
+	}
+	rc.Tenant = ns.Tenant
 
 	// Check the expectations of the rc before counting active pods, otherwise a new pod can sneak in
 	// and update the expectations after we've retrieved active pods from the store. If a new pod enters

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -95,6 +95,10 @@ func NewCmdDescribe(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 
 func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string, options *DescribeOptions) error {
 	selector := cmdutil.GetFlagString(cmd, "selector")
+	var all bool = true
+	if cmdutil.GetFlagString(cmd, "namespace") != "" {
+		all = false
+	}
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
@@ -111,7 +115,7 @@ func RunDescribe(f *cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 	mapper, typer := f.Object()
 	r := resource.NewBuilder(mapper, typer, f.ClientMapperForCommand()).
 		ContinueOnError().
-		NamespaceParam(cmdNamespace).DefaultNamespace().
+		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(all).
 		TenantParam(cmdTenant).DefaultTenant().
 		FilenameParam(enforceTenant, enforceNamespace, options.Filenames...).
 		SelectorParam(selector).


### PR DESCRIPTION
#### Test Request

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl describe rc
Name:       nginx
Namespace:  test
Image(s):   nginx
Selector:   app=nginx
Labels:     app=nginx
Replicas:   3 current / 3 desired
Pods Status:    3 Running / 0 Waiting / 0 Succeeded / 0 Failed
No volumes.
Events:
  FirstSeen LastSeen    Count   From                SubobjectPath   Reason          Message
  ─────────   ────────    ───── ────                ───────────── ──────          ───────
  30m       30m     1   {replication-controller }           SuccessfulCreate    Created pod: nginx-ljuuj
  30m       30m     1   {replication-controller }           SuccessfulCreate    Created pod: nginx-gp4bi
  30m       30m     1   {replication-controller }           SuccessfulCreate    Created pod: nginx-cq0ye
```

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl describe rc nginx --namespace=test
Name:       nginx
Namespace:  test
Image(s):   nginx
Selector:   app=nginx
Labels:     app=nginx
Replicas:   3 current / 3 desired
Pods Status:    3 Running / 0 Waiting / 0 Succeeded / 0 Failed
No volumes.
Events:
  FirstSeen LastSeen    Count   From                SubobjectPath   Reason          Message
  ─────────   ────────    ───── ────                ───────────── ──────          ───────
  30m       30m     1   {replication-controller }           SuccessfulCreate    Created pod: nginx-ljuuj
  30m       30m     1   {replication-controller }           SuccessfulCreate    Created pod: nginx-gp4bi
  30m       30m     1   {replication-controller }           SuccessfulCreate    Created pod: nginx-cq0ye
```

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl describe pods nginx-ljuuj --namespace=test
Name:               nginx-ljuuj
Namespace:          test
Image(s):           nginx
Node:               127.0.0.1/127.0.0.1
Start Time:         Sun, 25 Oct 2015 08:40:48 +0800
Labels:             app=nginx
Status:             Running
Reason:
Message:
IP:             172.17.0.18
Replication Controllers:    nginx (3/3 replicas created)
Containers:
  nginx:
    Container ID:   docker://6fa874186bbef3456525c0256b6122f8d50a313ef074f233d43e82c4c151be2d
    Image:      nginx
    Image ID:       docker://0b354d33906d30ac52d2817ea770ddce18c7531e58b5b3ca0ae78873f5d2e207
    QoS Tier:
      cpu:      BestEffort
      memory:       BestEffort
    State:      Running
      Started:      Sun, 25 Oct 2015 08:40:49 +0800
    Ready:      True
    Restart Count:  0
    Environment Variables:
Conditions:
  Type      Status
  Ready     True
Volumes:
  default-token-qftna:
    Type:   Secret (a secret that should populate this volume)
    SecretName: default-token-qftna
Events:
  FirstSeen LastSeen    Count   From            SubobjectPath               Reason      Message
  ─────────   ────────    ───── ────            ─────────────             ──────      ───────
  30m       30m     1   {scheduler }                            Scheduled   Successfully assigned nginx-ljuuj to 127.0.0.1
  30m       30m     1   {kubelet 127.0.0.1} implicitly required container POD   Pulled      Container image "gcr.io/google_containers/pause:0.8.0" already present on machine
  30m       30m     1   {kubelet 127.0.0.1} implicitly required container POD   Created     Created with docker id 9914a8fc8439
  30m       30m     1   {kubelet 127.0.0.1} implicitly required container POD   Started     Started with docker id 9914a8fc8439
  30m       30m     1   {kubelet 127.0.0.1} spec.containers{nginx}          Pulled      Container image "nginx" already present on machine
  30m       30m     1   {kubelet 127.0.0.1} spec.containers{nginx}          Created     Created with docker id 6fa874186bbe
  30m       30m     1   {kubelet 127.0.0.1} spec.containers{nginx}          Started     Started with docker id 6fa874186bbe
```
