### PR TITLE
prohibit non-admin users creating namespaces without network

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1829,12 +1829,16 @@ func ValidateTenantStatusUpdate(newTenant, oldTenant *api.Tenant) errs.Validatio
 }
 
 // ValidateNamespace tests if required fields are set.
-func ValidateNamespace(namespace *api.Namespace) errs.ValidationErrorList {
+func ValidateNamespace(namespace *api.Namespace, admin bool) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, ValidateObjectMeta(&namespace.ObjectMeta, false, ValidateNamespaceName).Prefix("metadata")...)
 
 	for i := range namespace.Spec.Finalizers {
 		allErrs = append(allErrs, validateFinalizerName(string(namespace.Spec.Finalizers[i]))...)
+	}
+
+	if !admin && namespace.Spec.Network == "" {
+		allErrs = append(allErrs, errs.NewFieldInvalid("spec.network", "", fmt.Sprintf("non-admin users can not create/update namespace without network")))
 	}
 	return allErrs
 }

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -3232,11 +3232,21 @@ func TestValidateNamespace(t *testing.T) {
 				Finalizers: []api.FinalizerName{"example.com/something", "example.com/other"},
 			},
 		},
+		{
+			ObjectMeta: api.ObjectMeta{Name: "abc-123"},
+			Spec: api.NamespaceSpec{
+				Finalizers: []api.FinalizerName{"example.com/something", "example.com/other"},
+				Network:    "test",
+			},
+		},
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateNamespace(&successCase); len(errs) != 0 {
+		if errs := ValidateNamespace(&successCase, true); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
+	}
+	if errs := ValidateNamespace(&successCases[2], false); len(errs) != 0 {
+		t.Errorf("expected success: %v", errs)
 	}
 	errorCases := map[string]struct {
 		R api.Namespace
@@ -3256,10 +3266,19 @@ func TestValidateNamespace(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		errs := ValidateNamespace(&v.R)
+		errs := ValidateNamespace(&v.R, true)
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		}
+	}
+	v := api.Namespace{
+		ObjectMeta: api.ObjectMeta{Name: "abc-123"},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{"example.com/something", "example.com/other"},
+		},
+	}
+	if errs := ValidateNamespace(&v, false); len(errs) == 0 {
+		t.Errorf("expected failure for invalid network")
 	}
 }
 


### PR DESCRIPTION
Fix issue https://github.com/hyperhq/hypernetes/issues/25
#### Manual test

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get ns
NAME      LABELS    TENANT    STATUS    AGE
default   <none>    default   Active    5s
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl create -f docs/user-guide/ns.yaml  --username=test --password=test
The Namespace "test" is invalid.
spec.network: invalid value '', Details: non-admin users can not create/update namespace without network
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl create -f docs/user-guide/ns.yaml
namespace "test" created
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get ns
NAME      LABELS     TENANT    STATUS    AGE
default   <none>     default   Active    29s
test      app=test   default   Active    7s
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl delete ns test
namespace "test" deleted
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl config set-cluster local --server=http://127.0.0.1:8080 --insecure-skip-tls-verify=true
cluster "local" set.
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get ns
NAME      LABELS    TENANT    STATUS    AGE
default   <none>    default   Active    1m
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl create -f docs/user-guide/ns.yaml  --username=test --password=test
namespace "test" created
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl delete ns test
namespace "test" deleted
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl create -f docs/user-guide/ns.yaml
namespace "test" created
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get ns
NAME      LABELS     TENANT    STATUS    AGE
default   <none>     default   Active    1m
test      app=test   default   Active    3s
root@ubuntu:/home/lei/src/k8s.io/kubernetes#
```
#### Unit test

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# hack/test-go.sh pkg/api/validation/
Running tests for APIVersion: v1,experimental/v1alpha1 with etcdPrefix: registry
+++ [1104 12:41:18] Running tests without code coverage
=== RUN   TestValidateEvent
--- PASS: TestValidateEvent (0.00s)
=== RUN   TestLoad
--- PASS: TestLoad (0.03s)
=== RUN   TestValidateOk
--- PASS: TestValidateOk (0.04s)
=== RUN   TestInvalid
--- PASS: TestInvalid (0.03s)
=== RUN   TestValid
--- PASS: TestValid (0.04s)
=== RUN   TestVersionRegex
--- PASS: TestVersionRegex (0.00s)
=== RUN   TestValidateObjectMetaCustomName
--- PASS: TestValidateObjectMetaCustomName (0.00s)
=== RUN   TestValidateObjectMetaNamespaces
--- PASS: TestValidateObjectMetaNamespaces (0.00s)
=== RUN   TestValidateObjectMetaUpdateIgnoresCreationTimestamp
--- PASS: TestValidateObjectMetaUpdateIgnoresCreationTimestamp (0.00s)
=== RUN   TestValidateObjectMetaTrimsTrailingSlash
--- PASS: TestValidateObjectMetaTrimsTrailingSlash (0.00s)
=== RUN   TestValidateLabels
--- PASS: TestValidateLabels (0.00s)
=== RUN   TestValidateAnnotations
--- PASS: TestValidateAnnotations (0.00s)
=== RUN   TestValidatePersistentVolumes
--- PASS: TestValidatePersistentVolumes (0.00s)
=== RUN   TestValidatePersistentVolumeClaim
--- PASS: TestValidatePersistentVolumeClaim (0.00s)
=== RUN   TestValidateVolumes
--- PASS: TestValidateVolumes (0.00s)
=== RUN   TestValidatePorts
--- PASS: TestValidatePorts (0.00s)
=== RUN   TestValidateEnv
--- PASS: TestValidateEnv (0.00s)
=== RUN   TestValidateVolumeMounts
--- PASS: TestValidateVolumeMounts (0.00s)
=== RUN   TestValidateProbe
--- PASS: TestValidateProbe (0.00s)
=== RUN   TestValidateHandler
--- PASS: TestValidateHandler (0.00s)
=== RUN   TestValidatePullPolicy
--- PASS: TestValidatePullPolicy (0.00s)
=== RUN   TestValidateContainers
--- PASS: TestValidateContainers (0.00s)
=== RUN   TestValidateRestartPolicy
--- PASS: TestValidateRestartPolicy (0.00s)
=== RUN   TestValidateDNSPolicy
--- PASS: TestValidateDNSPolicy (0.00s)
=== RUN   TestValidatePodSpec
--- PASS: TestValidatePodSpec (0.00s)
=== RUN   TestValidatePod
--- PASS: TestValidatePod (0.00s)
=== RUN   TestValidatePodUpdate
--- PASS: TestValidatePodUpdate (0.00s)
=== RUN   TestValidateService
--- PASS: TestValidateService (0.00s)
=== RUN   TestValidateReplicationControllerUpdate
--- PASS: TestValidateReplicationControllerUpdate (0.00s)
=== RUN   TestValidateReplicationController
--- PASS: TestValidateReplicationController (0.00s)
=== RUN   TestValidateNode
--- PASS: TestValidateNode (0.00s)
=== RUN   TestValidateNodeUpdate
--- PASS: TestValidateNodeUpdate (0.00s)
=== RUN   TestValidateServiceUpdate
--- PASS: TestValidateServiceUpdate (0.00s)
=== RUN   TestValidateResourceNames
--- PASS: TestValidateResourceNames (0.00s)
=== RUN   TestValidateLimitRange
--- PASS: TestValidateLimitRange (0.00s)
=== RUN   TestValidateResourceQuota
--- PASS: TestValidateResourceQuota (0.00s)
=== RUN   TestValidateNamespace
--- PASS: TestValidateNamespace (0.00s)
=== RUN   TestValidateNamespaceFinalizeUpdate
--- PASS: TestValidateNamespaceFinalizeUpdate (0.00s)
=== RUN   TestValidateNamespaceStatusUpdate
--- PASS: TestValidateNamespaceStatusUpdate (0.00s)
=== RUN   TestValidateNamespaceUpdate
--- PASS: TestValidateNamespaceUpdate (0.00s)
=== RUN   TestValidateSecret
--- PASS: TestValidateSecret (0.00s)
=== RUN   TestValidateDockerConfigSecret
--- PASS: TestValidateDockerConfigSecret (0.00s)
=== RUN   TestValidateEndpoints
--- PASS: TestValidateEndpoints (0.00s)
=== RUN   TestValidateSecurityContext
--- PASS: TestValidateSecurityContext (0.00s)
=== RUN   TestValidPodLogOptions
--- PASS: TestValidPodLogOptions (0.00s)
PASS
ok      k8s.io/kubernetes/pkg/api/validation    0.165s
Running tests for APIVersion: v1,experimental/v1alpha1 with etcdPrefix: kubernetes.io/registry
+++ [1104 12:41:22] Running tests without code coverage
=== RUN   TestValidateEvent
--- PASS: TestValidateEvent (0.00s)
=== RUN   TestLoad
--- PASS: TestLoad (0.03s)
=== RUN   TestValidateOk
--- PASS: TestValidateOk (0.05s)
=== RUN   TestInvalid
--- PASS: TestInvalid (0.03s)
=== RUN   TestValid
--- PASS: TestValid (0.04s)
=== RUN   TestVersionRegex
--- PASS: TestVersionRegex (0.00s)
=== RUN   TestValidateObjectMetaCustomName
--- PASS: TestValidateObjectMetaCustomName (0.00s)
=== RUN   TestValidateObjectMetaNamespaces
--- PASS: TestValidateObjectMetaNamespaces (0.00s)
=== RUN   TestValidateObjectMetaUpdateIgnoresCreationTimestamp
--- PASS: TestValidateObjectMetaUpdateIgnoresCreationTimestamp (0.00s)
=== RUN   TestValidateObjectMetaTrimsTrailingSlash
--- PASS: TestValidateObjectMetaTrimsTrailingSlash (0.00s)
=== RUN   TestValidateLabels
--- PASS: TestValidateLabels (0.00s)
=== RUN   TestValidateAnnotations
--- PASS: TestValidateAnnotations (0.00s)
=== RUN   TestValidatePersistentVolumes
--- PASS: TestValidatePersistentVolumes (0.00s)
=== RUN   TestValidatePersistentVolumeClaim
--- PASS: TestValidatePersistentVolumeClaim (0.00s)
=== RUN   TestValidateVolumes
--- PASS: TestValidateVolumes (0.00s)
=== RUN   TestValidatePorts
--- PASS: TestValidatePorts (0.00s)
=== RUN   TestValidateEnv
--- PASS: TestValidateEnv (0.00s)
=== RUN   TestValidateVolumeMounts
--- PASS: TestValidateVolumeMounts (0.00s)
=== RUN   TestValidateProbe
--- PASS: TestValidateProbe (0.00s)
=== RUN   TestValidateHandler
--- PASS: TestValidateHandler (0.00s)
=== RUN   TestValidatePullPolicy
--- PASS: TestValidatePullPolicy (0.00s)
=== RUN   TestValidateContainers
--- PASS: TestValidateContainers (0.00s)
=== RUN   TestValidateRestartPolicy
--- PASS: TestValidateRestartPolicy (0.00s)
=== RUN   TestValidateDNSPolicy
--- PASS: TestValidateDNSPolicy (0.00s)
=== RUN   TestValidatePodSpec
--- PASS: TestValidatePodSpec (0.00s)
=== RUN   TestValidatePod
--- PASS: TestValidatePod (0.00s)
=== RUN   TestValidatePodUpdate
--- PASS: TestValidatePodUpdate (0.00s)
=== RUN   TestValidateService
--- PASS: TestValidateService (0.00s)
=== RUN   TestValidateReplicationControllerUpdate
--- PASS: TestValidateReplicationControllerUpdate (0.00s)
=== RUN   TestValidateReplicationController
--- PASS: TestValidateReplicationController (0.00s)
=== RUN   TestValidateNode
--- PASS: TestValidateNode (0.00s)
=== RUN   TestValidateNodeUpdate
--- PASS: TestValidateNodeUpdate (0.00s)
=== RUN   TestValidateServiceUpdate
--- PASS: TestValidateServiceUpdate (0.00s)
=== RUN   TestValidateResourceNames
--- PASS: TestValidateResourceNames (0.00s)
=== RUN   TestValidateLimitRange
--- PASS: TestValidateLimitRange (0.00s)
=== RUN   TestValidateResourceQuota
--- PASS: TestValidateResourceQuota (0.00s)
=== RUN   TestValidateNamespace
--- PASS: TestValidateNamespace (0.00s)
=== RUN   TestValidateNamespaceFinalizeUpdate
--- PASS: TestValidateNamespaceFinalizeUpdate (0.00s)
=== RUN   TestValidateNamespaceStatusUpdate
--- PASS: TestValidateNamespaceStatusUpdate (0.00s)
=== RUN   TestValidateNamespaceUpdate
--- PASS: TestValidateNamespaceUpdate (0.00s)
=== RUN   TestValidateSecret
--- PASS: TestValidateSecret (0.00s)
=== RUN   TestValidateDockerConfigSecret
--- PASS: TestValidateDockerConfigSecret (0.00s)
=== RUN   TestValidateEndpoints
--- PASS: TestValidateEndpoints (0.00s)
=== RUN   TestValidateSecurityContext
--- PASS: TestValidateSecurityContext (0.00s)
=== RUN   TestValidPodLogOptions
--- PASS: TestValidPodLogOptions (0.00s)
PASS
ok      k8s.io/kubernetes/pkg/api/validation    0.164s
```
