### PR TITLE
sync namespaces and tenants while deleting a namespace & cleanup

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -85,7 +85,7 @@ func validateObject(obj runtime.Object) (errors []error) {
 		}
 		errors = validation.ValidateEndpoints(t)
 	case *api.Namespace:
-		errors = validation.ValidateNamespace(t)
+		errors = validation.ValidateNamespace(t, true)
 	case *api.Tenant:
 		errors = validation.ValidateTenant(t)
 	case *api.Secret:

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1807,7 +1807,6 @@ func ValidateTenant(tenant *api.Tenant) errs.ValidationErrorList {
 func ValidateTenantUpdate(newTenant *api.Tenant, oldTenant *api.Tenant) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, ValidateObjectMetaUpdate(&newTenant.ObjectMeta, &oldTenant.ObjectMeta).Prefix("metadata")...)
-	newTenant.Spec = oldTenant.Spec
 	newTenant.Status = oldTenant.Status
 	return allErrs
 }
@@ -1815,7 +1814,6 @@ func ValidateTenantUpdate(newTenant *api.Tenant, oldTenant *api.Tenant) errs.Val
 func ValidateTenantStatusUpdate(newTenant, oldTenant *api.Tenant) errs.ValidationErrorList {
 	allErrs := errs.ValidationErrorList{}
 	allErrs = append(allErrs, ValidateObjectMetaUpdate(&newTenant.ObjectMeta, &oldTenant.ObjectMeta).Prefix("metadata")...)
-	newTenant.Spec = oldTenant.Spec
 	if newTenant.DeletionTimestamp.IsZero() {
 		if newTenant.Status.Phase != api.TenantActive {
 			allErrs = append(allErrs, errs.NewFieldInvalid("Status.Phase", newTenant.Status.Phase, "A tenant may only be in active status if it does not have a deletion timestamp."))

--- a/pkg/registry/tenant/strategy.go
+++ b/pkg/registry/tenant/strategy.go
@@ -56,7 +56,6 @@ func (tenantStrategy) PrepareForCreate(obj runtime.Object) {
 func (tenantStrategy) PrepareForUpdate(obj, old runtime.Object) {
 	newTenant := obj.(*api.Tenant)
 	oldTenant := old.(*api.Tenant)
-	newTenant.Spec.Namespaces = oldTenant.Spec.Namespaces
 	newTenant.Status = oldTenant.Status
 }
 


### PR DESCRIPTION
- sync namespaces and tenants while deleting a namespace
- some cleanup
#### Manual test

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl create -f docs/user-guide/ns.yaml
namespace "test" created
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" https://127.0.0.1:6443/api/v1/tenants
{
  "kind": "TenantList",
  "apiVersion": "v1",
  "metadata": {
    "selfLink": "/api/v1/tenants",
    "resourceVersion": "228"
  },
  "items": [
    {
      "metadata": {
        "name": "default",
        "selfLink": "/api/v1/tenants/default",
        "uid": "3e2130c9-82d6-11e5-b31f-000c2986b7f9",
        "resourceVersion": "227",
        "creationTimestamp": "2015-11-04T09:27:18Z"
      },
      "spec": {
        "namespaces": [
          {
            "metadata": {
              "name": "test",
              "tenant": "default",
              "selfLink": "/api/v1/namespaces/test",
              "uid": "476b02d2-82d6-11e5-b31f-000c2986b7f9",
              "resourceVersion": "220",
              "creationTimestamp": "2015-11-04T09:27:33Z",
              "labels": {
                "app": "test"
              }
            },
            "spec": {
              "finalizers": [
                "kubernetes"
              ]
            },
            "status": {
              "phase": "Active"
            }
          },
          {
            "metadata": {
              "name": "default",
              "tenant": "default",
              "selfLink": "/api/v1/namespaces/default",
              "uid": "3e20a2e8-82d6-11e5-b31f-000c2986b7f9",
              "resourceVersion": "222",
              "creationTimestamp": "2015-11-04T09:27:18Z"
            },
            "spec": {
              "finalizers": [
                "kubernetes"
              ]
            },
            "status": {
              "phase": "Active"
            }
          }
        ]
      },
      "status": {
        "phase": "Active"
      }
    }
  ]
}
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl delete ns test
namespace "test" deleted
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" https://127.0.0.1:6443/api/v1/tenants
{
  "kind": "TenantList",
  "apiVersion": "v1",
  "metadata": {
    "selfLink": "/api/v1/tenants",
    "resourceVersion": "306"
  },
  "items": [
    {
      "metadata": {
        "name": "default",
        "selfLink": "/api/v1/tenants/default",
        "uid": "3e2130c9-82d6-11e5-b31f-000c2986b7f9",
        "resourceVersion": "306",
        "creationTimestamp": "2015-11-04T09:27:18Z"
      },
      "spec": {
        "namespaces": [
          {
            "metadata": {
              "name": "default",
              "tenant": "default",
              "selfLink": "/api/v1/namespaces/default",
              "uid": "3e20a2e8-82d6-11e5-b31f-000c2986b7f9",
              "resourceVersion": "302",
              "creationTimestamp": "2015-11-04T09:27:18Z"
            },
            "spec": {
              "finalizers": [
                "kubernetes"
              ]
            },
            "status": {
              "phase": "Active"
            }
          }
        ]
      },
      "status": {
        "phase": "Active"
      }
    }
  ]
}
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" https://127.0.0.1:6443/api/v1/namespaces
{
  "kind": "NamespaceList",
  "apiVersion": "v1",
  "metadata": {
    "selfLink": "/api/v1/namespaces",
    "resourceVersion": "447"
  },
  "items": [
    {
      "metadata": {
        "name": "default",
        "tenant": "default",
        "selfLink": "/api/v1/namespaces/default",
        "uid": "3e20a2e8-82d6-11e5-b31f-000c2986b7f9",
        "resourceVersion": "446",
        "creationTimestamp": "2015-11-04T09:27:18Z"
      },
      "spec": {
        "finalizers": [
          "kubernetes"
        ]
      },
      "status": {
        "phase": "Active"
      }
    }
  ]
}
```
