### PR TITLE
fix tenant issues while creating a network by admin

### DIFF
--- a/hack/test-go.sh
+++ b/hack/test-go.sh
@@ -44,7 +44,7 @@ kube::test::find_dirs() {
 }
 
 # -covermode=atomic becomes default with -race in Go >=1.3
-KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 120s}
+KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout 180s}
 KUBE_COVER=${KUBE_COVER:-n} # set to 'y' to enable coverage collection
 KUBE_COVERMODE=${KUBE_COVERMODE:-atomic}
 # How many 'go test' instances to run simultaneously when running tests in

--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -870,24 +870,14 @@ func filterListInTenant(obj runtime.Object, tenant string, kind string, namer Sc
 	if err != nil {
 		return err
 	}
-	if kind == "Tenant" {
-		for i := range items {
-			if _, name, err := namer.ObjectName(items[i]); err == nil {
-				if tenant == name {
-					result = append(result, items[i])
-				}
+	for i := range items {
+		if name, err := namer.ObjectTenant(items[i]); err == nil {
+			if tenant == name {
+				result = append(result, items[i])
+				continue
 			}
-		}
-	} else {
-		for i := range items {
-			if name, err := namer.ObjectTenant(items[i]); err == nil {
-				if tenant == name {
-					result = append(result, items[i])
-					continue
-				}
-				if name == "" {
-					result = append(result, items[i])
-				}
+			if name == "" {
+				result = append(result, items[i])
 			}
 		}
 	}

--- a/pkg/auth/authorizer/keystone/keystone.go
+++ b/pkg/auth/authorizer/keystone/keystone.go
@@ -114,7 +114,11 @@ func (ka *keystoneAuthorizer) Authorize(a authorizer.Attributes) (string, error)
 		}
 	}
 	if authorizer.IsWhiteListedUser(a.GetUserName()) {
-		return tenantName, nil
+		if a.GetUserName() != api.UserAdmin {
+			return tenantName, nil
+		} else {
+			return api.TenantDefault, nil
+		}
 	} else {
 		if !a.IsReadOnly() && a.GetResource() == "tenants" {
 			return "", errors.New("only admin can write tenant")


### PR DESCRIPTION
#### Test result

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl create -f /tmp/nw.yaml
network "valid-network" created
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get net
NAME            SUBNETS            PROVIDERNETWORKID   TENANT    LABELS    STATUS
valid-network   172.172.172.0/24                       default   <none>    Initializing
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get net --username=test --password=test
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get net valid-network -o yaml
apiVersion: v1
kind: Network
metadata:
  creationTimestamp: 2015-11-19T02:01:30Z
  name: valid-network
  resourceVersion: "1495"
  selfLink: /api/v1/networks/valid-network
  tenant: default
  uid: 734ec1e2-8e61-11e5-aa3b-000c2986b7f9
spec:
  subnets:
    subnet1:
      cidr: 172.172.172.0/24
      gateway: 172.172.172.1
status:
  phase: Initializing
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl delete net valid-network
network "valid-network" deleted
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl create -f /tmp/nw.yaml --username=test --password=test
network "valid-network" created
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get net valid-network -o yaml
apiVersion: v1
kind: Network
metadata:
  creationTimestamp: 2015-11-19T02:02:10Z
  name: valid-network
  resourceVersion: "2030"
  selfLink: /api/v1/networks/valid-network
  tenant: test
  uid: 8b967e6d-8e61-11e5-aa3b-000c2986b7f9
spec:
  subnets:
    subnet1:
      cidr: 172.172.172.0/24
      gateway: 172.172.172.1
status:
  phase: Initializing
root@ubuntu:/home/lei/src/k8s.io/kubernetes#
```
