### PR TITLE
non-admin users can not visit nodes and componentstatuses

### DIFF
--- a/test/integration/auth_keystone_test.go
+++ b/test/integration/auth_keystone_test.go
@@ -95,6 +95,13 @@ func getAdminTestRequests() []RequestTerm {
 		{"POST", path("tenants", "", ""), testTenant, code201},
 		{"GET", path("tenants", "", ""), "", code200},
 		{"POST", path("namespaces", "", ""), testNamespace, code201},
+
+		// Normal methods on nodes
+		{"GET", path("nodes", "", ""), "", code200},
+		{"POST", timeoutPath("nodes", "", ""), aNode, code201},
+		{"PUT", timeoutPath("nodes", "", "a"), aNode, code200},
+		{"GET", path("nodes", "", "a"), "", code200},
+		{"DELETE", timeoutPath("nodes", "", "a"), "", code200},
 	}
 	comRequests := getCommonTestRequests()
 	comDefaultRequests := getTestRequestsWithNamespace(NamespaceDefault)
@@ -124,6 +131,12 @@ func getTestRequestsForibidden() []RequestTerm {
 	requests := []RequestTerm{
 		// Tenants
 		{"POST", path("tenants", "", ""), testTenant, code201},
+
+		// Normal methods on nodes
+		{"GET", path("nodes", "", ""), "", code403},
+		{"POST", timeoutPath("nodes", "", ""), aNode, code403},
+		{"PUT", timeoutPath("nodes", "", "a"), aNode, code403},
+		{"DELETE", timeoutPath("nodes", "", "a"), "", code403},
 	}
 	comDefaultRequests := getTestRequestsWithNamespace(NamespaceDefault)
 	requests = append(requests, comDefaultRequests...)

--- a/test/integration/auth_test.go
+++ b/test/integration/auth_test.go
@@ -272,13 +272,6 @@ func getCommonTestRequests() []RequestTerm {
 		{"GET", path("services", "", ""), "", code200},
 		{"GET", path("endpoints", "", ""), "", code200},
 
-		// Normal methods on nodes
-		{"GET", path("nodes", "", ""), "", code200},
-		{"POST", timeoutPath("nodes", "", ""), aNode, code201},
-		{"PUT", timeoutPath("nodes", "", "a"), aNode, code200},
-		{"GET", path("nodes", "", "a"), "", code200},
-		{"DELETE", timeoutPath("nodes", "", "a"), "", code200},
-
 		{"GET", path("replicationControllers", "", ""), "", code200},
 		{"GET", path("events", "", ""), "", code200},
 		{"GET", path("foo", "", ""), "", code404},


### PR DESCRIPTION
## Test Result
### Before

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic dGVzdDp0ZXN0" https://127.0.0.1:6443/api/v1/componentstatus
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "the server could not find the requested resource",
  "reason": "NotFound",
  "details": {},
  "code": 404
}
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic dGVzdDp0ZXN0" https://127.0.0.1:6443/api/v1/componentstatuses
{
  "kind": "ComponentStatusList",
  "apiVersion": "v1",
  "metadata": {
    "selfLink": "/api/v1/componentstatuses"
  },
  "items": [
    {
      "metadata": {
        "name": "controller-manager",
        "selfLink": "/api/v1/componentstatuses/controller-manager",
        "creationTimestamp": null
      },
      "conditions": [
        {
          "type": "Healthy",
          "status": "True",
          "message": "ok"
        }
      ]
    },
    {
      "metadata": {
        "name": "scheduler",
        "selfLink": "/api/v1/componentstatuses/scheduler",
        "creationTimestamp": null
      },
      "conditions": [
        {
          "type": "Healthy",
          "status": "True",
          "message": "ok"
        }
      ]
    },
    {
      "metadata": {
        "name": "etcd-0",
        "selfLink": "/api/v1/componentstatuses/etcd-0",
        "creationTimestamp": null
      },
      "conditions": [
        {
          "type": "Healthy",
          "status": "True",
          "message": "{\"health\": \"true\"}"
        }
      ]
    }
  ]
}
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic dGVzdDp0ZXN0" https://127.0.0.1:6443/api/v1/componentstatuses/controller-manager
{
  "kind": "ComponentStatus",
  "apiVersion": "v1",
  "metadata": {
    "name": "controller-manager",
    "selfLink": "/api/v1/componentstatuses/controller-manager",
    "creationTimestamp": null
  },
  "conditions": [
    {
      "type": "Healthy",
      "status": "True",
      "message": "ok"
    }
  ]
}
```
### After

```
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic dGVzdDp0ZXN0" https://127.0.0.1:6443/api/v1/componentstatuses
Forbidden: "/api/v1/componentstatuses"root@ubuntu:/home/lei/src/k8s.io/kubernetes#
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" https://127.0.0.1:6443/api/v1/componentstatuses
{
  "kind": "ComponentStatusList",
  "apiVersion": "v1",
  "metadata": {
    "selfLink": "/api/v1/componentstatuses"
  },
  "items": [
    {
      "metadata": {
        "name": "controller-manager",
        "selfLink": "/api/v1/componentstatuses/controller-manager",
        "creationTimestamp": null
      },
      "conditions": [
        {
          "type": "Healthy",
          "status": "True",
          "message": "ok"
        }
      ]
    },
    {
      "metadata": {
        "name": "scheduler",
        "selfLink": "/api/v1/componentstatuses/scheduler",
        "creationTimestamp": null
      },
      "conditions": [
        {
          "type": "Healthy",
          "status": "True",
          "message": "ok"
        }
      ]
    },
    {
      "metadata": {
        "name": "etcd-0",
        "selfLink": "/api/v1/componentstatuses/etcd-0",
        "creationTimestamp": null
      },
      "conditions": [
        {
          "type": "Healthy",
          "status": "True",
          "message": "{\"health\": \"true\"}"
        }
      ]
    }
  ]
}
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic dGVzdDp0ZXN0" https://127.0.0.1:6443/api/v1/componentstatuses/controller-manager
Forbidden: "/api/v1/componentstatuses/controller-manager"root@ubuntu:/home/lei/src/k8s.io/kubernetes#
root@ubuntu:/home/lei/src/k8s.io/kubernetes# curl -k -X GET -H "Authorization: Basic YWRtaW46YWRtaW4=" https://127.0.0.1:6443/api/v1/componentstatuses/controller-manager
{
  "kind": "ComponentStatus",
  "apiVersion": "v1",
  "metadata": {
    "name": "controller-manager",
    "selfLink": "/api/v1/componentstatuses/controller-manager",
    "creationTimestamp": null
  },
  "conditions": [
    {
      "type": "Healthy",
      "status": "True",
      "message": "ok"
    }
  ]
}
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get node
NAME        LABELS                             STATUS    AGE
127.0.0.1   kubernetes.io/hostname=127.0.0.1   Ready     13m
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get node --username=test --password=test
Error from server: the server does not allow access to the requested resource (get nodes)
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get node controller-manager --username=test --password=test
Error from server: node "controller-manager" not found
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get node controller-manager
Error from server: node "controller-manager" not found
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get cs controller-manager
NAME                 STATUS    MESSAGE   ERROR
controller-manager   Healthy   ok
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get cs controller-manager --username=test --password=test
Error from server: the server does not allow access to the requested resource (get componentstatuses controller-manager)
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get cs --username=test --password=test
Error from server: the server does not allow access to the requested resource (get componentstatuses)
root@ubuntu:/home/lei/src/k8s.io/kubernetes# kubectl get cs
NAME                 STATUS    MESSAGE              ERROR
controller-manager   Healthy   ok
scheduler            Healthy   ok
etcd-0               Healthy   {"health": "true"}
```
