### PR TITLE
Fix hyper container id

### DIFF
--- a/pkg/kubelet/hyper/hyper.go
+++ b/pkg/kubelet/hyper/hyper.go
@@ -177,10 +177,6 @@ func parseTimeString(str string) (time.Time, error) {
 	return t, nil
 }
 
-func (r *runtime) buildContainerID(hyperContainerID string) string {
-	return typeHyper + "://" + hyperContainerID
-}
-
 func (r *runtime) getContainerStatus(container ContainerStatus, image, imageID string) *kubecontainer.ContainerStatus {
 	status := &kubecontainer.ContainerStatus{}
 
@@ -192,7 +188,7 @@ func (r *runtime) getContainerStatus(container ContainerStatus, image, imageID s
 	status.Name = containerName
 	status.ID = kubecontainer.ContainerID{
 		Type: typeHyper,
-		ID:   r.buildContainerID(container.ContainerID),
+		ID:   container.ContainerID,
 	}
 	status.Image = image
 	status.ImageID = imageID


### PR DESCRIPTION
Fix hyper container id to: `hyper://fcaef91c7b603017a93702bbf7561985268402f60c1bf07b0554427e6567f60a`
